### PR TITLE
Split files and fixed Filter problems

### DIFF
--- a/Cpp_files/BatchGenerator.C
+++ b/Cpp_files/BatchGenerator.C
@@ -1,0 +1,68 @@
+#include <iostream>
+#include <tuple>
+#include <vector>
+#include <algorithm>
+
+#include "TMVA/RTensor.hxx"
+#include "ROOT/RDataFrame.hxx"
+
+class BatchGenerator
+{
+private:
+    size_t current_row = 0, batch_size, num_rows, num_columns;
+    TMVA::Experimental::RTensor<float>* x_tensor;
+    bool drop_last;
+
+public:
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Constructors
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    BatchGenerator(const size_t batch_size, const size_t num_columns, bool drop_last=true) 
+                : batch_size(batch_size), num_columns(num_columns), drop_last(drop_last) {}
+    
+    BatchGenerator(TMVA::Experimental::RTensor<float>* x_tensor, const size_t batch_size, const size_t num_columns, 
+                bool drop_last=true) 
+                : x_tensor(x_tensor), batch_size(batch_size), num_columns(num_columns), drop_last(drop_last) {}
+
+    BatchGenerator(TMVA::Experimental::RTensor<float>* x_tensor, const size_t batch_size, const size_t num_rows, 
+                const size_t num_columns, bool drop_last=true) 
+                : x_tensor(x_tensor), batch_size(batch_size), num_rows(num_rows), num_columns(num_columns), drop_last(drop_last) {}
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Batch function
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    TMVA::Experimental::RTensor<float> operator()()
+    {
+        if (current_row + batch_size <= num_rows)
+        {
+            unsigned long offset = current_row * num_columns;
+            TMVA::Experimental::RTensor<float> x_batch(x_tensor->GetData() + offset, {batch_size, num_columns});
+
+            current_row += batch_size;
+            return x_batch;
+        }
+        else
+        {            
+            // TODO: Implement drop_last
+            return x_tensor->Slice({{0, 0}, {0, 0}});
+        }
+    }
+    bool HasData() {return (current_row + batch_size <= num_rows);}
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Getters and Setters
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    void SetNumRows(size_t r) {num_rows = r;}
+
+    void Reset(size_t num_rows) {
+        this->num_rows = num_rows;
+        this->current_row = 0;
+    }
+
+    void SetTensor(TMVA::Experimental::RTensor<float>* x_tensor, const size_t num_rows) {
+        this->x_tensor = x_tensor;
+        this->num_rows = num_rows;
+        this->current_row = 0;
+    }
+
+};

--- a/Cpp_files/DataLoader.C
+++ b/Cpp_files/DataLoader.C
@@ -1,0 +1,84 @@
+#include <iostream>
+#include <tuple>
+#include <vector>
+#include <algorithm>
+
+#include "TMVA/RTensor.hxx"
+#include "ROOT/RDataFrame.hxx"
+
+// Primary template for the DataLoader class. 
+// Required for the second class template to work
+template <typename F, typename U>
+class DataLoader;
+
+// Dataloader class used to load content of a RDataFrame onto a RTensor.
+template <typename T, std::size_t... N>
+class DataLoader<T, std::index_sequence<N...>>
+{
+    // Magic used to make make_index_sequence work.
+    // Code is based on the SofieFunctorHelper
+    template <std::size_t Idx>
+    using AlwaysT = T;
+
+    std::vector<std::vector<T>> fInput;
+
+private:
+    size_t num_rows, num_columns, current_row = 0;
+    bool random_order;
+
+    std::vector<size_t> row_order;
+    TMVA::Experimental::RTensor<float>& x_tensor;
+
+public:
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Constructor
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    DataLoader(TMVA::Experimental::RTensor<float>& x_tensor, const size_t num_columns, const size_t num_rows, bool random_order=true)
+        : x_tensor(x_tensor), num_columns(num_columns), num_rows(num_rows), random_order(random_order)
+    {
+        // Create a vector with elements 0...num_rows
+        row_order = std::vector<size_t>(num_rows);
+        std::iota(row_order.begin(), row_order.end(), 0);
+
+
+        // Randomize the order
+        if (random_order) {
+            std::random_shuffle(row_order.begin(), row_order.end());
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Value assigning
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Assign the values of a given row to the TMVA::Experimental::RTensor
+    template <typename First_T>
+    void assign_to_tensor(size_t offset, size_t i, First_T first)
+    {
+        x_tensor.GetData()[offset + i] = first;
+    }
+    template <typename First_T, typename... Rest_T>
+    void assign_to_tensor(size_t offset, size_t i, First_T first, Rest_T... rest)
+    {
+        x_tensor.GetData()[offset + i] = first;
+        assign_to_tensor(offset, ++i, std::forward<Rest_T>(rest)...);
+    }
+
+    // Load the values of a row onto a random row of the Tensor
+    void operator()(AlwaysT<N>... values)
+    {
+        if (current_row >= num_rows)
+            return;
+
+        assign_to_tensor(row_order[current_row] * num_columns , 0, std::forward<AlwaysT<N>>(values)...);
+
+        current_row++;
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Getters and Setters
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    size_t GetCurrentRow() 
+    {
+        return current_row;
+    }
+};

--- a/Cpp_files/myBatcher.C
+++ b/Cpp_files/myBatcher.C
@@ -3,162 +3,53 @@
 #include <vector>
 #include <algorithm>
 
+// Include ROOT files
 #include "TMVA/RTensor.hxx"
 #include "ROOT/RDataFrame.hxx"
 
-// Primary template for the DataLoader class. 
-// Required for the second class template to work
-template <typename F, typename U>
-class DataLoader;
+// Include my classes
+#include "DataLoader.C"
+#include "BatchGenerator.C"
 
-// Dataloader class used to load content of a RDataFrame onto a RTensor.
-template <typename T, std::size_t... N>
-class DataLoader<T, std::index_sequence<N...>>
+//
+size_t load_dataC(TMVA::Experimental::RTensor<float>& x_tensor, ROOT::RDF::RNode x_rdf,
+                std::vector<std::string> cols, const size_t num_columns, 
+                const size_t chunk_rows, const size_t start_row = 0, bool random_order=true) 
 {
-    // Magic used to make make_index_sequence work.
-    // Code is based on the SofieFunctorHelper
-    template <std::size_t Idx>
-    using AlwaysT = T;
+    // Fill the RTensor with the data from the RDataFrame
+    DataLoader<float, std::make_index_sequence<4>> func(x_tensor, 
+                        num_columns, chunk_rows, random_order);
 
-    std::vector<std::vector<T>> fInput;
+    auto myCount = x_rdf.Range(start_row, start_row + chunk_rows).Count();
 
-private:
-    size_t num_rows, num_columns, current_row = 0;
-    bool random_order;
+    x_rdf.Range(start_row, start_row + chunk_rows).Foreach(func, cols);
 
-    std::vector<size_t> row_order;
-    TMVA::Experimental::RTensor<float>& x_tensor;
-
-public:
-    DataLoader(TMVA::Experimental::RTensor<float>& x_tensor, const size_t num_columns, const size_t num_rows, bool random_order=true)
-        : x_tensor(x_tensor), num_columns(num_columns), num_rows(num_rows), random_order(random_order)
-    {
-        // Create a vector with elements 0...num_rows
-        row_order = std::vector<size_t>(num_rows);
-        std::iota(row_order.begin(), row_order.end(), 0);
-
-
-        // Randomize the order
-        if (random_order) {
-            std::random_shuffle(row_order.begin(), row_order.end());
-        }
-    }
-
-    // Assign the values of a given row to the TMVA::Experimental::RTensor
-    template <typename First_T>
-    void assign_to_tensor(size_t offset, size_t i, First_T first)
-    {
-        x_tensor.GetData()[offset + i] = first;
-    }
-    template <typename First_T, typename... Rest_T>
-    void assign_to_tensor(size_t offset, size_t i, First_T first, Rest_T... rest)
-    {
-        x_tensor.GetData()[offset + i] = first;
-        assign_to_tensor(offset, ++i, std::forward<Rest_T>(rest)...);
-    }
-
-    // Load the values of a row onto a random row of the Tensor
-    void operator()(AlwaysT<N>... values)
-    {
-        if (current_row >= num_rows)
-            return;
-
-        assign_to_tensor(row_order[current_row] * num_columns , 0, std::forward<AlwaysT<N>>(values)...);
-
-        current_row++;
-    }
-
-    size_t GetCurrentRow() 
-    {
-        return current_row;
-    }
-};
-
-class Generator_t
-{
-private:
-    size_t current_row = 0, batch_size, num_rows, num_columns;
-    TMVA::Experimental::RTensor<float>* x_tensor;
-    bool drop_last;
-
-public:
-
-    Generator_t(const size_t batch_size, const size_t num_columns, bool drop_last=true) 
-                : batch_size(batch_size), num_columns(num_columns), drop_last(drop_last) {}
-    
-    Generator_t(TMVA::Experimental::RTensor<float>* x_tensor, const size_t batch_size, const size_t num_columns, 
-                bool drop_last=true) 
-                : x_tensor(x_tensor), batch_size(batch_size), num_columns(num_columns), drop_last(drop_last) {}
-
-    Generator_t(TMVA::Experimental::RTensor<float>* x_tensor, const size_t batch_size, const size_t num_rows, 
-                const size_t num_columns, bool drop_last=true) 
-                : x_tensor(x_tensor), batch_size(batch_size), num_rows(num_rows), num_columns(num_columns), drop_last(drop_last) {}
-
-    // Return a batch from the data
-    TMVA::Experimental::RTensor<float> operator()()
-    {
-        if (current_row + batch_size <= num_rows)
-        {
-            unsigned long offset = current_row * num_columns;
-            TMVA::Experimental::RTensor<float> x_batch(x_tensor->GetData() + offset, {batch_size, num_columns});
-
-            current_row += batch_size;
-            return x_batch;
-        }
-        else
-        {            
-            // TODO: Implement drop_last
-            return x_tensor->Slice({{0, 0}, {0, 0}});
-        }
-    }
-
-    void SetNumRows(size_t r) {num_rows = r;}
-
-    void Reset(size_t num_rows) {
-        this->num_rows = num_rows;
-        this->current_row = 0;
-    }
-
-    void SetTensor(TMVA::Experimental::RTensor<float>* x_tensor, const size_t num_rows) {
-        this->x_tensor = x_tensor;
-        this->num_rows = num_rows;
-        this->current_row = 0;
-    }
-
-    bool HasData() {return (current_row + batch_size <= num_rows);}
-};
-
+    return myCount.GetValue();
+}
 
 void myBatcher()
 {
     // Define variables
     std::vector<std::string> cols = {"m_jj", "m_jjj", "m_jlv", "m_lv"};
-    size_t batch_size = 10, start_row = 0, num_rows = 10, num_columns = cols.size();
+    size_t batch_size = 2, start_row = 0, num_rows = 5, num_columns = cols.size();
     bool random_order = false, drop_last = false;
 
     // Load the RDataFrame and create a new tensor
     ROOT::RDataFrame x_rdf = ROOT::RDataFrame("testTree", "data/testFile.root", cols);
+    auto x_filter = x_rdf.Filter("m_jj < 1");
+
     // ROOT::RDataFrame x_rdf = ROOT::RDataFrame("sig_tree", "Higgs_data.root", cols);
     TMVA::Experimental::RTensor<float> x_tensor({num_rows, num_columns});
 
     // Fill the RTensor with the data from the RDataFrame
-    DataLoader<float, std::make_index_sequence<4>>
-        func(x_tensor, num_columns, num_rows, random_order);
-
-    x_rdf.Range(start_row, start_row + num_rows).Foreach(func, cols);
-
-    // func(1, 2, 4, 5);
-
-    // std::cout << x_tensor << std::endl;
-
-    // std::cout << "current_row: " << func.GetCurrentRow() << std::endl;
+    size_t count = load_dataC(x_tensor, x_filter, cols, num_columns, num_rows, 0, false);
 
     // define generator
-    Generator_t* generator = new Generator_t(batch_size, num_columns, drop_last);
+    BatchGenerator* generator = new BatchGenerator(batch_size, num_columns, drop_last);
 
     generator->SetTensor(&x_tensor, num_rows);
 
-    // Generate new batches until all data has been returned
+    // // Generate new batches until all data has been returned
     while (generator->HasData()) {
         auto batch = (*generator)();
 

--- a/Python_files/batch_generator.py
+++ b/Python_files/batch_generator.py
@@ -8,7 +8,7 @@ class Generator:
                  batch_rows: int, num_chuncks: int=1, use_whole_file: bool=True):
         
         # Initialize parameters
-        self.x_rdf = x_rdf
+        self.x_node = ROOT.RDF.AsRNode(x_rdf)
         self.columns = columns
         self.chunk_rows = chunk_rows
         self.current_chunck = 0
@@ -22,7 +22,7 @@ class Generator:
 
         # Create C++ function
         ROOT.gInterpreter.ProcessLine("""
-size_t load_data(TMVA::Experimental::RTensor<float>& x_tensor, ROOT::RDataFrame x_rdf,
+size_t load_data(TMVA::Experimental::RTensor<float>& x_tensor, ROOT::RDF::RNode x_rdf,
                 std::vector<std::string> cols, const size_t num_columns, 
                 const size_t chunk_rows, const size_t start_row = 0, bool random_order=true) 
 {
@@ -41,7 +41,7 @@ size_t load_data(TMVA::Experimental::RTensor<float>& x_tensor, ROOT::RDataFrame 
 """)
         # Create x_tensor
         self.x_tensor = ROOT.TMVA.Experimental.RTensor("float")([self.chunk_rows, self.num_columns])    
-        self.generator = ROOT.Generator_t(self.batch_rows, self.num_columns)
+        self.generator = ROOT.BatchGenerator(self.batch_rows, self.num_columns)
 
         self.load_data()
 
@@ -52,7 +52,8 @@ size_t load_data(TMVA::Experimental::RTensor<float>& x_tensor, ROOT::RDataFrame 
         start = self.current_chunck * self.chunk_rows
 
         # Fill x_tensor and get the number of rows that were processed
-        loaded_size = ROOT.load_data(self.x_tensor, x_rdf, self.columns, self.num_columns, self.chunk_rows, start)
+        loaded_size = ROOT.load_data(self.x_tensor, self.x_node, self.columns, self.num_columns, 
+                                     self.chunk_rows, start, False)
 
         #TODO: think about what to do if end of file is reached
         if (loaded_size < self.batch_rows):
@@ -90,17 +91,20 @@ size_t load_data(TMVA::Experimental::RTensor<float>& x_tensor, ROOT::RDataFrame 
 main_folder = "../"
 
 # Import myBatcher.C
-ROOT.gInterpreter.ProcessLine(f'#include "{main_folder}Cpp_files/myBatcher.C"')
+ROOT.gInterpreter.ProcessLine(f'#include "{main_folder}Cpp_files/DataLoader.C"')
+ROOT.gInterpreter.ProcessLine(f'#include "{main_folder}Cpp_files/BatchGenerator.C"')
 
 columns = ["m_jj", "m_jjj", "m_jlv"] 
 # x_rdf = ROOT.RDataFrame("sig_tree", f"{main_folder}data/Higgs_data_full.root", columns)
 x_rdf = ROOT.RDataFrame("testTree", f"{main_folder}data/testFile.root", columns)
 
+x_filter = x_rdf.Filter("m_jj < 1")
+
 num_columns = len(columns)
 batch_rows = 2
 chunk_rows = 5
 
-generator = Generator(x_rdf, columns, chunk_rows, batch_rows, use_whole_file=True)
+generator = Generator(x_filter, columns, chunk_rows, batch_rows, use_whole_file=True)
 
 for i, batch in enumerate(generator):
     print(f"batch {i}, {batch}")


### PR DESCRIPTION
The Dataloader and the BatchGenerator are placed into seperate files. 
A user can now provide the python batchgenerator with a filtered dataframe